### PR TITLE
Bugfix to allow for AVG operation when reducing across distributed pr…

### DIFF
--- a/src/lightning/fabric/utilities/distributed.py
+++ b/src/lightning/fabric/utilities/distributed.py
@@ -195,8 +195,8 @@ def _sync_ddp(result: Tensor, group: Optional[Any] = None, reduce_op: Optional[U
     op: Optional[ReduceOp]
     if isinstance(reduce_op, str):
         reduce_op = "avg" if reduce_op == "mean" else reduce_op
-        if reduce_op.lower() == "avg" and torch.distributed.get_backend(group) == "gloo":
-            # The GLOO backend does not support the `ReduceOp.AVG` operation
+        if reduce_op.lower() == "avg" and torch.distributed.get_backend(group) in ("ccl", "gloo"):
+            # The GLOO adn CCL backends do not support the `ReduceOp.AVG` operation
             op = ReduceOp.SUM  # type: ignore[assignment]
             divide_by_world_size = True
         else:


### PR DESCRIPTION
Hey Corey,

Thank you for this branch, it has been very useful while intel works on integrating IPEX with lightning. I ran into an error when synchronizing logged metrics during distributed training (i.e. `sync_dist=True`).

The problem seems to be that like `gloo`, `ccl` does not support the`ReduceOp.AVG` operation. This PR simply extends what lightning does for `gloo` to `ccl`.